### PR TITLE
Rewrite T[] Read<T> to have much much much better performance.

### DIFF
--- a/MemorySharp/Internals/MarshalType.cs
+++ b/MemorySharp/Internals/MarshalType.cs
@@ -139,8 +139,9 @@ namespace Binarysharp.MemoryManagement.Internals
         /// Marshals an array of byte to a managed object.
         /// </summary>
         /// <param name="byteArray">The array of bytes corresponding to a managed object.</param>
+        /// <param name="index">Where to start conversion of bytes to the managed object</param>
         /// <returns>A managed object.</returns>
-        public static T ByteArrayToObject(byte[] byteArray)
+        public static T ByteArrayToObject(byte[] byteArray, int index = 0)
         {
             // We'll tried to avoid marshalling as it really slows the process
             // First, check if the type can be converted without marhsalling
@@ -152,47 +153,47 @@ namespace Binarysharp.MemoryManagement.Internals
                         switch (byteArray.Length)
                         {
                             case 1:
-                                return (T)(object)new IntPtr(BitConverter.ToInt32(new byte[] { byteArray[0], 0x0, 0x0, 0x0 }, 0));
+                                return (T)(object)new IntPtr(BitConverter.ToInt32(new byte[] { byteArray[index], 0x0, 0x0, 0x0 }, index));
                             case 2:
-                                return (T)(object)new IntPtr(BitConverter.ToInt32(new byte[] { byteArray[0], byteArray[1], 0x0, 0x0 }, 0));
+                                return (T)(object)new IntPtr(BitConverter.ToInt32(new byte[] { byteArray[index], byteArray[index + 1], 0x0, 0x0 }, index));
                             case 4:
-                                return (T)(object)new IntPtr(BitConverter.ToInt32(byteArray, 0));
+                                return (T)(object)new IntPtr(BitConverter.ToInt32(byteArray, index));
                             case 8:
-                                return (T)(object)new IntPtr(BitConverter.ToInt64(byteArray, 0));
+                                return (T)(object)new IntPtr(BitConverter.ToInt64(byteArray, index));
                         }
                     }
                     break;
                 case TypeCode.Boolean:
-                    return (T)(object)BitConverter.ToBoolean(byteArray, 0);
+                    return (T)(object)BitConverter.ToBoolean(byteArray, index);
                 case TypeCode.Byte:
-                    return (T)(object)byteArray[0];
+                    return (T)(object)byteArray[index];
                 case TypeCode.Char:
-                    return (T) (object) Encoding.UTF8.GetChars(byteArray)[0]; //BitConverter.ToChar(byteArray, 0);
+                    return (T)(object)Encoding.UTF8.GetChars(byteArray)[index]; //BitConverter.ToChar(byteArray, 0);
                 case TypeCode.Double:
-                    return (T)(object)BitConverter.ToDouble(byteArray, 0);
+                    return (T)(object)BitConverter.ToDouble(byteArray, index);
                 case TypeCode.Int16:
-                    return (T)(object)BitConverter.ToInt16(byteArray, 0);
+                    return (T)(object)BitConverter.ToInt16(byteArray, index);
                 case TypeCode.Int32:
-                    return (T)(object)BitConverter.ToInt32(byteArray, 0);
+                    return (T)(object)BitConverter.ToInt32(byteArray, index);
                 case TypeCode.Int64:
-                    return (T)(object)BitConverter.ToInt64(byteArray, 0);
+                    return (T)(object)BitConverter.ToInt64(byteArray, index);
                 case TypeCode.Single:
-                    return (T)(object)BitConverter.ToSingle(byteArray, 0);
+                    return (T)(object)BitConverter.ToSingle(byteArray, index);
                 case TypeCode.String:
                     throw new InvalidCastException("This method doesn't support string conversion.");
                 case TypeCode.UInt16:
-                    return (T)(object)BitConverter.ToUInt16(byteArray, 0);
+                    return (T)(object)BitConverter.ToUInt16(byteArray, index);
                 case TypeCode.UInt32:
-                    return (T)(object)BitConverter.ToUInt32(byteArray, 0);
+                    return (T)(object)BitConverter.ToUInt32(byteArray, index);
                 case TypeCode.UInt64:
-                    return (T)(object)BitConverter.ToUInt64(byteArray, 0);
+                    return (T)(object)BitConverter.ToUInt64(byteArray, index);
             }
             // Check if it's not a common type
             // Allocate a block of unmanaged memory
             using (var unmanaged = new LocalUnmanagedMemory(Size))
             {
                 // Write the array of bytes inside the unmanaged memory
-                unmanaged.Write(byteArray);
+                unmanaged.Write(byteArray, index);
                 // Return a managed object created from the block of unmanaged memory
                 return unmanaged.Read<T>();
             }

--- a/MemorySharp/Memory/LocalUnmanagedMemory.cs
+++ b/MemorySharp/Memory/LocalUnmanagedMemory.cs
@@ -102,10 +102,11 @@ namespace Binarysharp.MemoryManagement.Memory
         /// Writes an array of bytes to the unmanaged block of memory.
         /// </summary>
         /// <param name="byteArray">The array of bytes to write.</param>
-        public void Write(byte[] byteArray)
+        /// <param name="index">The start position to copy bytes from</param>
+        public void Write(byte[] byteArray,int index = 0)
         {
             // Copy the array of bytes into the block of memory
-            Marshal.Copy(byteArray, 0, Address, Size);
+            Marshal.Copy(byteArray, index, Address, Size);
         }
         /// <summary>
         /// Write data to the unmanaged block of memory.

--- a/MemorySharp/MemorySharp.cs
+++ b/MemorySharp/MemorySharp.cs
@@ -306,11 +306,26 @@ namespace Binarysharp.MemoryManagement
         {
             // Allocate an array to store the results
             var array = new T[count];
-            // Read the array in the remote process
-            for (var i = 0; i < count; i++)
+
+            // Read all the memory at once, much faster then reading each time individually
+            var bytes = ReadBytes(address, MarshalType<T>.Size*count, isRelative);
+
+            //If we check the type we can gain an additional boost of speed
+            //ofcourse if we wrote an unmanaged module and used that here itd go even faster then this.
+            if (typeof (T) != typeof (byte))
             {
-                array[i] = Read<T>(address + MarshalType<T>.Size * i, isRelative);
+                for (var i = 0; i < count; i++)
+                {
+                    array[i] = MarshalType<T>.ByteArrayToObject(bytes, MarshalType<T>.Size * i);
+                }
             }
+            else
+            {
+                //Just copy the bytes
+                Buffer.BlockCopy(bytes,0,array,0,count);
+            }
+            
+
             return array;
         }
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -322,4 +322,4 @@ This is because there are so many people ready to share their skills that I deci
 ## Author ##
 
 This developer and the copyright holder of this library is [ZenLulz (Jämes Ménétrey)](https://github.com/ZenLulz).  
-The official website of MemorySharp is [www.binarysharp.com](http://ww.binarysharp.com).
+The official website of MemorySharp is [www.binarysharp.com](http://www.binarysharp.com).


### PR DESCRIPTION
Performance could be greatly improved  further by writing an unmanaged module and use of unsafe code.

These changes pass the unit tests.

I wrote a patternscanner I'd like to get merged into the project. Since readbytes isn't public you have to go through T[] Read<T> and its really really really slow.